### PR TITLE
Improve compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ scalaVersion in ThisBuild := Versions.scalaVersion
 scalaVersion := "2.12.8"
 
 
+
 // settings for a native-packager based docker project based on sbt-docker plugin
 def sbtdockerAppBase(id: String)(base: String = id): Project = Project(id, base = file(base))
   .enablePlugins(sbtdocker.DockerPlugin, JavaAppPackaging)
@@ -36,7 +37,14 @@ def sbtdockerAppBase(id: String)(base: String = id): Project = Project(id, base 
   )
 
 lazy val model = (project in file("model"))
-  .settings(libraryDependencies ++= Seq(jsonGenerator, abstractOperator))
+  .enablePlugins(ModelGeneratorPlugin)
+  .settings(
+    libraryDependencies ++= Seq(jsonGenerator, abstractOperator),
+    modelSchemaLocation := "./schema/flinkCluster.json",
+    (compile in Compile) := ((compile in Compile) dependsOn generateModel).value
+  
+  )
+
 
 lazy val operator = sbtdockerAppBase("fdp-flink-operator")("./operator")
   .settings(mainClass in Compile := Some("io.radanalytics.operator.Entrypoint"))

--- a/model/src/main/scala/com/lightbend/operator/model/GenerateModel.scala
+++ b/model/src/main/scala/com/lightbend/operator/model/GenerateModel.scala
@@ -16,16 +16,13 @@ object GenerateModel {
     val source = this.getClass.getClassLoader.getResource("./schema/flinkCluster.json")
 
     val outputPojoDirectory=new File("./model/target/generated-sources/jsonschema2pojo/")
-    outputPojoDirectory.exists() match {
-      case false => outputPojoDirectory.mkdirs()
-      case _ =>
+    if (!outputPojoDirectory.exists()) {
+      outputPojoDirectory.mkdirs()
     }
 
     val config = new DefaultGenerationConfig() {
-      override def isGenerateBuilders: Boolean = { // set config option by overriding method
-        true
-      }
-   }
+      override val isGenerateBuilders: Boolean = true  // set config option by overriding method
+    }
 
     val mapper = new SchemaMapper(new RuleFactory(config, new Jackson2Annotator(config), new SchemaStore()), new SchemaGenerator())
     mapper.generate(codeModel, "FlinkCluster", "com.lightbend.operator.types", source)

--- a/project/ModelGeneratorPlugin.scala
+++ b/project/ModelGeneratorPlugin.scala
@@ -1,0 +1,53 @@
+import sbt._
+import org.jsonschema2pojo._
+import org.jsonschema2pojo.rules.RuleFactory
+import java.io.File
+
+import com.sun.codemodel.JCodeModel
+import sbt.Opts.compile
+
+object ModelGeneratorPlugin extends AutoPlugin {
+
+  //override def trigger = allRequirements
+
+  object autoImport {
+    lazy val generateModel = taskKey[Unit]("Generates the Model from a JSON Schema")
+    lazy val modelSchemaLocation = settingKey[String]("The source for the schema definition")
+    lazy val sayHello = taskKey[Unit]("say hello")
+  }
+
+  import autoImport._
+
+  override def projectSettings = Seq(
+    generateModel := Def.taskDyn {
+      Def.task {
+        val schemaLocation = modelSchemaLocation.value
+        generate(schemaLocation)
+      }
+    }.value
+    
+  )
+
+  def generate(schemaResource: String)= {
+
+
+    val codeModel = new JCodeModel()
+    val source = new File(schemaResource).toURI.toURL
+    println(s"Using source: $source")
+
+    val outputPojoDirectory=new File("./target/generated-sources/jsonschema2pojo/")
+    if (!outputPojoDirectory.exists()) {
+      outputPojoDirectory.mkdirs()
+    }
+
+    val config = new DefaultGenerationConfig() {
+      override val isGenerateBuilders: Boolean = true  // set config option by overriding method
+    }
+
+    val mapper = new SchemaMapper(new RuleFactory(config, new Jackson2Annotator(config), new SchemaStore()), new SchemaGenerator())
+    mapper.generate(codeModel, "FlinkCluster", "com.lightbend.operator.types", source)
+    codeModel.build(outputPojoDirectory)
+  }
+}
+
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
 resolvers += "Bintray Repository" at "https://dl.bintray.com/shmishleniy/"
 
+libraryDependencies += "org.jsonschema2pojo" % "jsonschema2pojo-core" % "1.0.0"
+
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.4")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")

--- a/schema/flinkCluster.json
+++ b/schema/flinkCluster.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "A Flink cluster configuration",
+  "type": "object",
+  "extends": {
+    "type": "object",
+    "existingJavaType": "io.radanalytics.operator.common.EntityInfo"
+  },
+  "properties": {
+    "master": {
+      "$ref": "#/definitions/RCSpec"
+    },
+    "worker": {
+      "$ref": "#/definitions/RCSpec"
+    },
+    "customImage": {
+      "type": "string"
+    },
+    "metrics": {
+      "type": "boolean",
+      "default": "true"
+    },
+    "env": {
+      "$ref": "#/definitions/NameValue"
+    },
+    "flinkConfiguration": {
+      "existingJavaType" : "java.util.Map<String,String>",
+      "type" : "object"
+    },
+    "labels" : {
+      "existingJavaType" : "java.util.Map<String,String>",
+      "type" : "object"
+    }
+  },
+  "required": [ ],
+  "definitions": {
+    "RCSpec": {
+      "type": "object",
+      "properties": {
+        "memory": {
+          "type": "string"
+        },
+        "cpu": {
+          "type": "string"
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NameValue": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "value": { "type": "string" }
+        },
+        "required": ["name", "value"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Introduces an sbt plugin to eliminate the need to run the model generator by hand before being able to compile the operator code.

In other words, we can do:
```
git clone <prj>
sbt compile
```
without any preparatory steps.